### PR TITLE
Improve Excel export error handling

### DIFF
--- a/WM_Invoice_Parser/fast_invoice_extractor.py
+++ b/WM_Invoice_Parser/fast_invoice_extractor.py
@@ -131,7 +131,14 @@ def main():
         return
 
     df = pd.DataFrame(all_records)
-    df.to_excel(OUTPUT_PATH, index=False)
+    try:
+        df.to_excel(OUTPUT_PATH, index=False)
+    except ImportError as exc:
+        logging.error("Failed to write Excel file: %s", exc)
+        logging.error(
+            "Ensure the 'openpyxl' package is installed to enable Excel export"
+        )
+        return
     logging.info("Extraction complete. Results saved to %s", OUTPUT_PATH)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- show a clear error when exporting to Excel fails

## Testing
- `python - <<'EOF'
import pandas as pd
try:
    pd.DataFrame({'A':[1]}).to_excel('test.xlsx')
    print('OK')
except Exception as e:
    print('Error', e)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68893e44b2e48331a447f20ae9191fef