### PR TITLE
Add multi-page PDF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ The `WM_Invoice_Parser` directory holds earlier invoice extraction tests and is 
   ```bash
   PYTHONPATH=analyzer_projects/Lindamood_Ticket_Analyzer_v1 pytest
   ```
+- Multi-page PDFs can be parsed page-by-page using the new `process_receipt_pages` helper.
 - Further information is available in `docs/receipt_analyzer_user_guide.md` and `docs/receipt_analyzer_technical_details.md`.
 

--- a/docs/receipt_analyzer_technical_details.md
+++ b/docs/receipt_analyzer_technical_details.md
@@ -8,11 +8,12 @@ This document describes the implementation of the receipt processing utility loc
 - **`tests/test_receipt_utils.py`** – Unit tests that validate the field extraction logic.
 
 ## Processing Flow
-1. **`extract_text`** uses the DocTR OCR model to read text lines from an image or PDF.
-2. **`extract_fields`** scans those lines with regular expressions, populating a `ReceiptFields` object. Vendors are categorized using `CATEGORY_MAP`.
-3. **`process_receipt`** moves the original file into a category folder and returns the extracted fields.
-4. **`ReceiptFileHandler`** watches the input directory for new files and records each processed receipt to an Excel workbook using `pandas`.
-5. **`run_batch`** performs initial processing of any files already present before the watcher starts.
+1. **`extract_text_pages`** returns OCR text for each page of an image or PDF.
+2. **`extract_text`** flattens those results into a single list of lines.
+3. **`extract_fields`** scans those lines with regular expressions, populating a `ReceiptFields` object. Vendors are categorized using `CATEGORY_MAP`.
+4. **`process_receipt`** moves the original file into a category folder and returns the extracted fields. The helper `process_receipt_pages` can be used for multi-page PDFs to obtain one `ReceiptFields` instance per page.
+5. **`ReceiptFileHandler`** watches the input directory for new files and records each processed receipt to an Excel workbook using `pandas`.
+6. **`run_batch`** performs initial processing of any files already present before the watcher starts.
 
 ## Development Notes
 - Tests can be executed from the repository root with:

--- a/docs/receipt_analyzer_user_guide.md
+++ b/docs/receipt_analyzer_user_guide.md
@@ -31,4 +31,5 @@ Stop the watcher with `Ctrl+C`.
 ## Customization
 - Modify `CATEGORY_MAP` in `receipt_processing/utils.py` to change how vendor keywords map to categories.
 - Update the `INPUT_DIR`, `OUTPUT_DIR` and `LOG_FILE` constants in `receipt_processing/main.py` to point to other locations.
+- Use `process_receipt_pages` if you need to extract fields from each page of a multi-page PDF.
 


### PR DESCRIPTION
## Summary
- add OCR helper `extract_text_pages` and `process_receipt_pages`
- update docs with details about handling multi-page PDFs

## Testing
- `PYTHONPATH='receipt _processor' pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688aa26f61ac8331b77cd2c0528f6426