### PR TITLE
Add image auto-cropping and renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains small experiments with document analysis. The most complete example is the **receipt analyzer** located under `analyzer_projects/Lindamood_Ticket_Analyzer_v1`.
 
-The receipt analyzer monitors a directory for new receipt images or PDFs, extracts information using OCR and simple regular expressions, then organizes the files into category folders while keeping a log in an Excel workbook.
+The receipt analyzer monitors a directory for new receipt images or PDFs, extracts information using OCR and simple regular expressions, then organizes the files into category folders while keeping a log in an Excel workbook. Image receipts are cropped before OCR and renamed based on the detected vendor and date.
 
 The `WM_Invoice_Parser` directory holds earlier invoice extraction tests and is not integrated with the receipt analyzer.
 

--- a/docs/receipt_analyzer_technical_details.md
+++ b/docs/receipt_analyzer_technical_details.md
@@ -11,7 +11,7 @@ This document describes the implementation of the receipt processing utility loc
 1. **`extract_text_pages`** returns OCR text for each page of an image or PDF.
 2. **`extract_text`** flattens those results into a single list of lines.
 3. **`extract_fields`** scans those lines with regular expressions, populating a `ReceiptFields` object. Vendors are categorized using `CATEGORY_MAP`.
-4. **`process_receipt_pages`** iterates through PDF pages, extracts fields for each one, moves the file into a category folder and returns a list of `ReceiptFields`. The helper `process_receipt` remains available for single-page receipts.
+4. **`process_receipt_pages`** iterates through PDF pages, auto-crops image files, extracts fields for each page, renames the file to `YYYYMMDD_VENDOR.ext`, moves it into a category folder and returns the extracted `ReceiptFields` list along with the final path. The helper `process_receipt` wraps the same logic for single-page receipts.
 5. **`ReceiptFileHandler`** watches the input directory for new files and records each page's fields to an Excel workbook using `pandas`.
 6. **`run_batch`** performs initial processing of any files already present before the watcher starts.
 

--- a/docs/receipt_analyzer_user_guide.md
+++ b/docs/receipt_analyzer_user_guide.md
@@ -24,7 +24,7 @@ python -m receipt_processing.main
 ```
 The script processes any receipts already in the input directory and then watches for new files. Supported formats are `.jpg`, `.jpeg`, `.png`, and `.pdf`.
 
-When a receipt is processed it will be moved into `OUTPUT_DIR/<category>` and a row will be appended to `LOG_FILE` containing the vendor, date, total and category.
+When a receipt is processed it will be moved into `OUTPUT_DIR/<category>` and a row will be appended to `LOG_FILE` containing the vendor, date, total and category. Image files are automatically cropped using simple document detection prior to OCR. After text extraction the file is renamed to `YYYYMMDD_VENDOR.ext` when possible (falling back to `receipt_<timestamp>.ext` if parsing fails).
 
 Stop the watcher with `Ctrl+C`.
 

--- a/receipt _processor/receipt_processing/main.py
+++ b/receipt _processor/receipt_processing/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import time
 from datetime import datetime
@@ -14,6 +15,13 @@ from watchdog.observers import Observer
 import pandas as pd
 
 from utils import CATEGORY_MAP, ReceiptFields, extract_fields
+
+try:  # Optional dependency for image processing
+    import cv2  # type: ignore
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - optional
+    cv2 = None
+    np = None
 
 
 # --- Configuration ---
@@ -67,13 +75,96 @@ def extract_text(filepath: Path) -> Iterable[str]:
     return lines
 
 
+def auto_crop_image(image_path: Path) -> Path:
+    """Attempt to detect the document boundaries and overwrite the image with a
+    cropped version. Returns the path that should be used for OCR."""
+    if cv2 is None or np is None:
+        return image_path
+
+    img = cv2.imread(str(image_path))
+    if img is None:
+        return image_path
+
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    gray = cv2.GaussianBlur(gray, (5, 5), 0)
+    edged = cv2.Canny(gray, 75, 200)
+
+    contours, _ = cv2.findContours(edged, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+    contours = sorted(contours, key=cv2.contourArea, reverse=True)
+    screen = None
+    for c in contours:
+        peri = cv2.arcLength(c, True)
+        approx = cv2.approxPolyDP(c, 0.02 * peri, True)
+        if len(approx) == 4:
+            screen = approx
+            break
+
+    if screen is None:
+        return image_path
+
+    pts = screen.reshape(4, 2).astype("float32")
+    s = pts.sum(axis=1)
+    rect = np.zeros((4, 2), dtype="float32")
+    rect[0] = pts[np.argmin(s)]
+    rect[2] = pts[np.argmax(s)]
+    diff = np.diff(pts, axis=1)
+    rect[1] = pts[np.argmin(diff)]
+    rect[3] = pts[np.argmax(diff)]
+
+    (tl, tr, br, bl) = rect
+    widthA = np.linalg.norm(br - bl)
+    widthB = np.linalg.norm(tr - tl)
+    maxW = int(max(widthA, widthB))
+    heightA = np.linalg.norm(tr - br)
+    heightB = np.linalg.norm(tl - bl)
+    maxH = int(max(heightA, heightB))
+
+    dst = np.array([[0, 0], [maxW - 1, 0], [maxW - 1, maxH - 1], [0, maxH - 1]], dtype="float32")
+    M = cv2.getPerspectiveTransform(rect, dst)
+    warped = cv2.warpPerspective(img, M, (maxW, maxH))
+
+    cv2.imwrite(str(image_path), warped)
+    return image_path
+
+
+def _parse_date(date_str: str) -> str | None:
+    """Return YYYYMMDD or None if parsing fails."""
+    for fmt in ("%m/%d/%Y", "%m/%d/%y", "%d/%m/%Y", "%d/%m/%y", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(date_str, fmt).strftime("%Y%m%d")
+        except ValueError:
+            pass
+    return None
+
+
+def rename_receipt_file(filepath: Path, vendor: str, date_str: str) -> Path:
+    """Rename the file using the vendor and date if available."""
+    date_fmt = _parse_date(date_str)
+    safe_vendor = re.sub(r"[^A-Za-z0-9]+", "_", vendor).strip("_") or "receipt"
+
+    if date_fmt:
+        new_name = f"{date_fmt}_{safe_vendor}{filepath.suffix.lower()}"
+    else:
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        new_name = f"receipt_{ts}{filepath.suffix.lower()}"
+
+    new_path = filepath.with_name(new_name)
+    filepath.rename(new_path)
+    return new_path
+
+
 # --- Main receipt processor ---
 def process_receipt(filepath: Path) -> ReceiptFields:
     print(f"Processing {filepath.name}...")
+
+    if filepath.suffix.lower() in {".jpg", ".jpeg", ".png"}:
+        filepath = auto_crop_image(filepath)
+
     lines = extract_text(filepath)
     fields = extract_fields(lines, CATEGORY_MAP)
 
-    # Move file to output folder
+    filepath = rename_receipt_file(filepath, fields.vendor, fields.date)
+
     category_folder = OUTPUT_DIR / fields.category
     category_folder.mkdir(parents=True, exist_ok=True)
     new_path = category_folder / filepath.name
@@ -82,14 +173,21 @@ def process_receipt(filepath: Path) -> ReceiptFields:
     return fields
 
 
-def process_receipt_pages(filepath: Path) -> List[ReceiptFields]:
+def process_receipt_pages(filepath: Path) -> tuple[List[ReceiptFields], Path]:
     """Process a multi-page PDF and return fields for each page."""
+
+    if filepath.suffix.lower() in {".jpg", ".jpeg", ".png"}:
+        filepath = auto_crop_image(filepath)
+
     pages = extract_text_pages(filepath)
     fields_list: List[ReceiptFields] = []
     for lines in pages:
         fields_list.append(extract_fields(lines, CATEGORY_MAP))
 
-    # Move once using the category from the first page
+    vendor = fields_list[0].vendor if fields_list else "receipt"
+    date_val = fields_list[0].date if fields_list else ""
+    filepath = rename_receipt_file(filepath, vendor, date_val)
+
     if fields_list:
         category_folder = OUTPUT_DIR / fields_list[0].category
     else:
@@ -98,7 +196,7 @@ def process_receipt_pages(filepath: Path) -> List[ReceiptFields]:
     new_path = category_folder / filepath.name
     shutil.move(str(filepath), str(new_path))
 
-    return fields_list
+    return fields_list, new_path
 
 
 class ReceiptFileHandler(FileSystemEventHandler):
@@ -114,11 +212,11 @@ class ReceiptFileHandler(FileSystemEventHandler):
             return
 
         try:
-            page_fields = process_receipt_pages(filepath)
+            page_fields, final_path = process_receipt_pages(filepath)
             records: list[dict[str, str]] = []
             for fields in page_fields:
                 record = {
-                    "filename": filepath.name,
+                    "filename": final_path.name,
                     "vendor": fields.vendor,
                     "date": fields.date,
                     "total": fields.total,
@@ -145,10 +243,10 @@ def run_batch() -> None:
     for file in INPUT_DIR.glob("*"):
         if file.suffix.lower() in {".jpg", ".jpeg", ".png", ".pdf"}:
             try:
-                page_fields = process_receipt_pages(file)
+                page_fields, final_path = process_receipt_pages(file)
                 for fields in page_fields:
                     record = {
-                        "filename": file.name,
+                        "filename": final_path.name,
                         "vendor": fields.vendor,
                         "date": fields.date,
                         "total": fields.total,


### PR DESCRIPTION
## Summary
- implement auto-cropping for image receipts using OpenCV
- rename receipts based on extracted vendor and date
- adjust watcher and batch processing to handle new filename
- document new features in README and docs

## Testing
- `PYTHONPATH='receipt _processor' pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ac429b7188331b241edbff7cf9998