### PR TITLE
Add auto-crop toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains small experiments with document analysis. The most complete example is the **receipt analyzer** located under `analyzer_projects/Lindamood_Ticket_Analyzer_v1`.
 
-The receipt analyzer monitors a directory for new receipt images or PDFs, extracts information using OCR and simple regular expressions, then organizes the files into category folders while keeping a log in an Excel workbook. Image receipts are cropped before OCR and renamed based on the detected vendor and date.
+The receipt analyzer monitors a directory for new receipt images or PDFs, extracts information using OCR and simple regular expressions, then organizes the files into category folders while keeping a log in an Excel workbook. Image receipts are cropped before OCR and renamed based on the detected vendor and date. Cropping can be disabled by setting ``AUTO_CROP_ENABLED = False`` in ``receipt_processing/main.py`` if it causes issues with your photos.
 
 The `WM_Invoice_Parser` directory holds earlier invoice extraction tests and is not integrated with the receipt analyzer.
 

--- a/docs/receipt_analyzer_technical_details.md
+++ b/docs/receipt_analyzer_technical_details.md
@@ -11,7 +11,7 @@ This document describes the implementation of the receipt processing utility loc
 1. **`extract_text_pages`** returns OCR text for each page of an image or PDF.
 2. **`extract_text`** flattens those results into a single list of lines.
 3. **`extract_fields`** scans those lines with regular expressions, populating a `ReceiptFields` object. Vendors are categorized using `CATEGORY_MAP`.
-4. **`process_receipt_pages`** iterates through PDF pages, auto-crops image files, extracts fields for each page, renames the file to `YYYYMMDD_VENDOR.ext`, moves it into a category folder and returns the extracted `ReceiptFields` list along with the final path. The helper `process_receipt` wraps the same logic for single-page receipts.
+4. **`process_receipt_pages`** iterates through PDF pages, auto-crops image files, extracts fields for each page, renames the file to `YYYYMMDD_VENDOR.ext`, moves it into a category folder and returns the extracted `ReceiptFields` list along with the final path. The helper `process_receipt` wraps the same logic for single-page receipts. Cropping can be disabled via the ``AUTO_CROP_ENABLED`` flag in `receipt_processing/main.py` if needed.
 5. **`ReceiptFileHandler`** watches the input directory for new files and records each page's fields to an Excel workbook using `pandas`.
 6. **`run_batch`** performs initial processing of any files already present before the watcher starts.
 

--- a/docs/receipt_analyzer_user_guide.md
+++ b/docs/receipt_analyzer_user_guide.md
@@ -24,7 +24,7 @@ python -m receipt_processing.main
 ```
 The script processes any receipts already in the input directory and then watches for new files. Supported formats are `.jpg`, `.jpeg`, `.png`, and `.pdf`.
 
-When a receipt is processed it will be moved into `OUTPUT_DIR/<category>` and a row will be appended to `LOG_FILE` containing the vendor, date, total and category. Image files are automatically cropped using simple document detection prior to OCR. After text extraction the file is renamed to `YYYYMMDD_VENDOR.ext` when possible (falling back to `receipt_<timestamp>.ext` if parsing fails).
+When a receipt is processed it will be moved into `OUTPUT_DIR/<category>` and a row will be appended to `LOG_FILE` containing the vendor, date, total and category. Image files are automatically cropped using simple document detection prior to OCR. After text extraction the file is renamed to `YYYYMMDD_VENDOR.ext` when possible (falling back to `receipt_<timestamp>.ext` if parsing fails). If cropping yields poor OCR results you can disable it by setting ``AUTO_CROP_ENABLED = False`` in `receipt_processing/main.py`.
 
 Stop the watcher with `Ctrl+C`.
 

--- a/receipt _processor/receipt_processing/main.py
+++ b/receipt _processor/receipt_processing/main.py
@@ -29,6 +29,10 @@ INPUT_DIR = Path(r"C:\Users\brian.atkins\Dropbox\Personal\Receipts\input")
 OUTPUT_DIR = Path(r"G:\My Drive\receipts\processed")
 LOG_FILE = Path(r"G:\My Drive\receipts\receipt_log.xlsx")
 
+# Enable or disable automatic image cropping prior to OCR.  Set to ``False``
+# if the cropping logic negatively impacts OCR accuracy for your photos.
+AUTO_CROP_ENABLED = True
+
 
 
 # --- Lazy OCR initialization ---
@@ -157,7 +161,7 @@ def rename_receipt_file(filepath: Path, vendor: str, date_str: str) -> Path:
 def process_receipt(filepath: Path) -> ReceiptFields:
     print(f"Processing {filepath.name}...")
 
-    if filepath.suffix.lower() in {".jpg", ".jpeg", ".png"}:
+    if AUTO_CROP_ENABLED and filepath.suffix.lower() in {".jpg", ".jpeg", ".png"}:
         filepath = auto_crop_image(filepath)
 
     lines = extract_text(filepath)
@@ -176,7 +180,7 @@ def process_receipt(filepath: Path) -> ReceiptFields:
 def process_receipt_pages(filepath: Path) -> tuple[List[ReceiptFields], Path]:
     """Process a multi-page PDF and return fields for each page."""
 
-    if filepath.suffix.lower() in {".jpg", ".jpeg", ".png"}:
+    if AUTO_CROP_ENABLED and filepath.suffix.lower() in {".jpg", ".jpeg", ".png"}:
         filepath = auto_crop_image(filepath)
 
     pages = extract_text_pages(filepath)


### PR DESCRIPTION
## Summary
- introduce `AUTO_CROP_ENABLED` option in receipt processor
- adjust receipt processing to respect the new flag
- document how to disable cropping in README and docs

## Testing
- `PYTHONPATH='receipt _processor' pytest -q 'receipt _processor/tests/test_receipt_utils.py'`

------
https://chatgpt.com/codex/tasks/task_e_688ad55954208331b8162fab7be06bfc