### PR TITLE
Handle alternate subtotal labels

### DIFF
--- a/receipt _processor/receipt_processing/utils.py
+++ b/receipt _processor/receipt_processing/utils.py
@@ -82,7 +82,7 @@ def extract_fields(
     for line in lines:
         lower = line.lower()
 
-        if subtotal is None and re.search(r"sub\s*total", lower):
+        if subtotal is None and re.search(r"sub[-\s]*total|net amount", lower):
             m = re.search(r"([0-9]+[.,][0-9]{2})", line.replace(",", ""))
             if m:
                 subtotal = float(m.group(1))

--- a/receipt _processor/tests/test_receipt_utils.py
+++ b/receipt _processor/tests/test_receipt_utils.py
@@ -1,3 +1,4 @@
+import pytest
 from receipt_processing.utils import (
     extract_fields,
     ReceiptFields,
@@ -39,5 +40,18 @@ def test_extract_fields_uncategorized():
     assert fields.subtotal is None
     assert fields.tax is None
     assert fields.payment_method is None
+
+
+@pytest.mark.parametrize("line", ["Sub-Total $10.00", "Net Amount $10.00"])
+def test_extract_fields_subtotal_variants(line):
+    lines = [
+        "Store",
+        "Date: 01/01/2024",
+        line,
+        "Tax $0.80",
+        "Total $10.80",
+    ]
+    fields = extract_fields(lines)
+    assert fields.subtotal == 10.00
 
 


### PR DESCRIPTION
## Summary
- expand subtotal pattern to recognise `sub-total` and `net amount`
- add tests for the new subtotal label variations

## Testing
- `PYTHONPATH='receipt _processor' pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ceee5cdc8331aa8b5670d2d4faf1