### PR TITLE
Improve receipt tax parsing

### DIFF
--- a/receipt _processor/tests/test_receipt_utils.py
+++ b/receipt _processor/tests/test_receipt_utils.py
@@ -42,6 +42,26 @@ def test_extract_fields_uncategorized():
     assert fields.payment_method is None
 
 
+def test_tax_percentage_ignored():
+    lines = [
+        "Shop",
+        "Sales Tax 8.25% 1.23",
+        "Total 10.00",
+    ]
+    fields = extract_fields(lines)
+    assert fields.tax == 1.23
+
+
+@pytest.mark.parametrize("label", ["GST", "HST", "VAT"])
+def test_tax_label_variants(label):
+    lines = [
+        "Store",
+        f"{label} 2.00",
+    ]
+    fields = extract_fields(lines)
+    assert fields.tax == 2.00
+
+
 @pytest.mark.parametrize("line", ["Sub-Total $10.00", "Net Amount $10.00"])
 def test_extract_fields_subtotal_variants(line):
     lines = [


### PR DESCRIPTION
## Summary
- add `_last_amount` helper to grab final monetary value on a line while ignoring percentages
- broaden tax detection to search for 'sales tax', 'gst', 'hst', or 'vat'
- test percentage-ignored tax and tax label variants

## Testing
- `PYTHONPATH='receipt _processor' pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890d07ab668833183425c4d497c4db9