### PR TITLE
Expand total regex variants

### DIFF
--- a/receipt _processor/receipt_processing/utils.py
+++ b/receipt _processor/receipt_processing/utils.py
@@ -113,7 +113,7 @@ def extract_fields(
             if amount is not None:
                 tax = amount
 
-        if total is None and re.search(r"\b(?:total|amount due)\b", lower):
+        if total is None and re.search(r"\b(?:total|grand total|amount due|balance due)\b", lower):
             amount = _last_amount(line)
             if amount is not None:
                 total = amount

--- a/receipt _processor/tests/test_receipt_utils.py
+++ b/receipt _processor/tests/test_receipt_utils.py
@@ -75,3 +75,13 @@ def test_extract_fields_subtotal_variants(line):
     assert fields.subtotal == 10.00
 
 
+@pytest.mark.parametrize("line", ["Grand Total $10.00", "Balance Due $10.00"])
+def test_extract_fields_total_variants(line):
+    lines = [
+        "Store",
+        line,
+    ]
+    fields = extract_fields(lines)
+    assert fields.total == 10.00
+
+


### PR DESCRIPTION
## Summary
- broaden total keyword regex to include "grand total" and "balance due"
- add tests for new total variants

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890d46783dc8331bc6df1b0d3bafd22