### PR TITLE
Compute missing totals and subtotals from receipt tax

### DIFF
--- a/docs/receipt_analyzer_technical_details.md
+++ b/docs/receipt_analyzer_technical_details.md
@@ -10,7 +10,7 @@ This document describes the implementation of the receipt processing utility loc
 ## Processing Flow
 1. **`extract_text_pages`** returns OCR text for each page of an image or PDF.
 2. **`extract_text`** flattens those results into a single list of lines.
-3. **`extract_fields`** scans those lines with regular expressions, populating a `ReceiptFields` object. Vendors are categorized using `CATEGORY_MAP`.
+3. **`extract_fields`** scans those lines with regular expressions, populating a `ReceiptFields` object. Vendors are categorized using `CATEGORY_MAP`. Missing totals or subtotals are computed from the other values when possible.
 4. **`process_receipt_pages`** iterates through PDF pages, auto-crops image files, extracts fields for each page, renames the file to `VENDOR_YYYYMMDD_PROCESSEDTIMESTAMP.ext`, moves it into a category folder and returns the extracted `ReceiptFields` list along with the final path. Cropping uses a safe bounding box approach with a margin so white receipts on light backgrounds are not clipped. The helper `process_receipt` wraps the same logic for single-page receipts. Cropping can be disabled via the ``AUTO_CROP_ENABLED`` flag in `receipt_processing/main.py` if needed.
 5. **`ReceiptFileHandler`** watches the input directory for new files and records each page's fields to an Excel workbook using `pandas`. The log columns are ordered as `date`, `vendor`, `subtotal`, `tax`, `total`, `category`, `payment_method`, `card_last4`, `filename`, `processed_time`.
 6. **`run_batch`** performs initial processing of any files already present before the watcher starts.

--- a/receipt _processor/receipt_processing/utils.py
+++ b/receipt _processor/receipt_processing/utils.py
@@ -131,6 +131,11 @@ def extract_fields(
                         card_last4 = card_match.group(1)
                     break
 
+    if total is None and subtotal is not None and tax is not None:
+        total = round(subtotal + tax, 2)
+    if subtotal is None and total is not None and tax is not None:
+        subtotal = round(total - tax, 2)
+
     date = date_match.group(1) if date_match else ""
     vendor = lines[0] if lines else "Unknown"
 

--- a/receipt _processor/tests/test_receipt_utils.py
+++ b/receipt _processor/tests/test_receipt_utils.py
@@ -85,3 +85,27 @@ def test_extract_fields_total_variants(line):
     assert fields.total == 10.00
 
 
+def test_compute_total_from_subtotal_and_tax():
+    lines = [
+        "Store",
+        "Subtotal $10.00",
+        "Tax $0.80",
+    ]
+    fields = extract_fields(lines)
+    assert fields.total == 10.80
+    assert fields.subtotal == 10.00
+    assert fields.tax == 0.80
+
+
+def test_compute_subtotal_from_total_and_tax():
+    lines = [
+        "Store",
+        "Tax $0.80",
+        "Total $10.80",
+    ]
+    fields = extract_fields(lines)
+    assert fields.subtotal == 10.00
+    assert fields.total == 10.80
+    assert fields.tax == 0.80
+
+


### PR DESCRIPTION
## Summary
- Derive missing `total` from `subtotal` and `tax` or compute `subtotal` when only `total` and `tax` are present.
- Document auto-computation of totals and subtotals in extract_fields workflow.
- Add unit tests covering derived totals and subtotals.

## Testing
- `PYTHONPATH='receipt _processor' pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890d70d34788331a99bfa12966d32de