### PR TITLE
Add receipt line item extraction and logging

### DIFF
--- a/receipt _processor/tests/test_receipt_utils.py
+++ b/receipt _processor/tests/test_receipt_utils.py
@@ -118,8 +118,20 @@ def test_line_item_parsing():
     ]
     fields = extract_fields(lines)
     assert fields.line_items == [
-        {"item": "Burger", "amount": 4.99},
-        {"item": "Fries", "amount": 2.99},
+        {"item_description": "Burger", "price": 4.99, "quantity": None, "tax": False},
+        {"item_description": "Fries", "price": 2.99, "quantity": None, "tax": False},
+    ]
+
+
+def test_line_item_with_quantity_and_tax():
+    lines = [
+        "Store",
+        "2 Burger 4.99 T",
+        "Total 9.98",
+    ]
+    fields = extract_fields(lines)
+    assert fields.line_items == [
+        {"item_description": "Burger", "price": 4.99, "quantity": 2, "tax": True},
     ]
 
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -18,6 +18,7 @@ else:
     st.warning("receipt_log.xlsx not found. A new file will be created on save.")
     df = pd.DataFrame(
         columns=[
+            "receipt_id",
             "date",
             "vendor",
             "subtotal",


### PR DESCRIPTION
## Summary
- capture detailed line items including quantity and tax indicators when parsing receipts
- log line items to a new `Receipt_Line_Items.xlsx` file with a `receipt_id` linking back to the main log
- expose the new `receipt_id` column in the Streamlit review app

## Testing
- `PYTHONPATH='receipt _processor' pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689221addbf483318c9dd1d249c3d77c