### PR TITLE
Implement item category assignment utility

### DIFF
--- a/receipt _processor/receipt_processing/utils.py
+++ b/receipt _processor/receipt_processing/utils.py
@@ -16,6 +16,45 @@ CATEGORY_MAP: dict[str, list[str]] = {
     "supplies": ["office depot", "staples", "lowes", "home depot"],
 }
 
+# Default item categories mapped to line item keywords
+ITEM_CATEGORY_MAP: dict[str, list[str]] = {
+    "food": ["burger", "fries", "sandwich"],
+    "drink": ["soda", "water", "coffee"],
+}
+
+
+def assign_item_category(
+    description: str, keyword_map: dict[str, list[str]] | None = None
+) -> str:
+    """Return an item category based on keywords in ``description``.
+
+    The mapping is case-insensitive and returns the first category with a
+    matching keyword. If no keywords match, ``"uncategorized"`` is returned.
+
+    Parameters
+    ----------
+    description:
+        The item description to categorize.
+    keyword_map:
+        Optional mapping of categories to keywords. If omitted,
+        :data:`ITEM_CATEGORY_MAP` is used.
+
+    Returns
+    -------
+    str
+        The matched category or ``"uncategorized"`` if no match is found.
+    """
+
+    if keyword_map is None:
+        keyword_map = ITEM_CATEGORY_MAP
+
+    desc = description.lower()
+    for category, keywords in keyword_map.items():
+        for kw in keywords:
+            if kw.lower() in desc:
+                return category
+    return "uncategorized"
+
 
 def load_vendor_categories(csv_path: str | Path) -> dict[str, str]:
     """Load a vendor to category mapping from a CSV file."""

--- a/receipt _processor/tests/test_receipt_utils.py
+++ b/receipt _processor/tests/test_receipt_utils.py
@@ -4,6 +4,7 @@ from receipt_processing.utils import (
     ReceiptFields,
     CATEGORY_MAP,
     load_vendor_categories,
+    assign_item_category,
 )
 
 
@@ -134,4 +135,17 @@ def test_line_item_with_quantity_and_tax():
         {"item_description": "Burger", "price": 4.99, "quantity": 2, "tax": True},
     ]
 
+
+def test_assign_item_category_match():
+    keyword_map = {
+        "food": ["burger", "fries"],
+        "beverage": ["soda", "cola"],
+    }
+    assert assign_item_category("Cheeseburger", keyword_map) == "food"
+    assert assign_item_category("Diet Cola", keyword_map) == "beverage"
+
+
+def test_assign_item_category_uncategorized():
+    keyword_map = {"food": ["burger"]}
+    assert assign_item_category("Laptop Sleeve", keyword_map) == "uncategorized"
 


### PR DESCRIPTION
## Summary
- add keyword-based item category mapping helper
- cover item categorization and fallback logic with tests

## Testing
- `PYTHONPATH="receipt _processor" pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689223aba164833181f06070ff20b350