### PR TITLE
Log item categories for receipt line items

### DIFF
--- a/receipt _processor/receipt_processing/main.py
+++ b/receipt _processor/receipt_processing/main.py
@@ -442,7 +442,7 @@ class ReceiptFileHandler(FileSystemEventHandler):
                             "price": item.get("price"),
                             "quantity": item.get("quantity"),
                             "tax": item.get("tax", False),
-                            "category": fields.category,
+                            "item_category": item.get("category"),
                         }
                     )
 
@@ -479,7 +479,7 @@ class ReceiptFileHandler(FileSystemEventHandler):
                         "price",
                         "quantity",
                         "tax",
-                        "category",
+                        "item_category",
                     ]
                 ]
                 if LINE_ITEMS_FILE.exists():
@@ -529,7 +529,7 @@ def run_batch() -> None:
                                 "price": item.get("price"),
                                 "quantity": item.get("quantity"),
                                 "tax": item.get("tax", False),
-                                "category": fields.category,
+                                "item_category": item.get("category"),
                             }
                         )
             except Exception as e:  # pragma: no cover - runtime protection
@@ -568,7 +568,7 @@ def run_batch() -> None:
                 "price",
                 "quantity",
                 "tax",
-                "category",
+                "item_category",
             ]
         ]
         if LINE_ITEMS_FILE.exists():

--- a/receipt _processor/receipt_processing/utils.py
+++ b/receipt _processor/receipt_processing/utils.py
@@ -292,6 +292,7 @@ def extract_fields(
                             "price": amount,
                             "quantity": qty,
                             "tax": tax_flag,
+                            "category": assign_item_category(desc),
                         }
                     )
                 if consumed_next:

--- a/receipt _processor/tests/test_receipt_utils.py
+++ b/receipt _processor/tests/test_receipt_utils.py
@@ -119,8 +119,20 @@ def test_line_item_parsing():
     ]
     fields = extract_fields(lines)
     assert fields.line_items == [
-        {"item_description": "Burger", "price": 4.99, "quantity": None, "tax": False},
-        {"item_description": "Fries", "price": 2.99, "quantity": None, "tax": False},
+        {
+            "item_description": "Burger",
+            "price": 4.99,
+            "quantity": None,
+            "tax": False,
+            "category": assign_item_category("Burger"),
+        },
+        {
+            "item_description": "Fries",
+            "price": 2.99,
+            "quantity": None,
+            "tax": False,
+            "category": assign_item_category("Fries"),
+        },
     ]
 
 
@@ -132,7 +144,13 @@ def test_line_item_with_quantity_and_tax():
     ]
     fields = extract_fields(lines)
     assert fields.line_items == [
-        {"item_description": "Burger", "price": 4.99, "quantity": 2, "tax": True},
+        {
+            "item_description": "Burger",
+            "price": 4.99,
+            "quantity": 2,
+            "tax": True,
+            "category": assign_item_category("Burger"),
+        },
     ]
 
 


### PR DESCRIPTION
## Summary
- categorize each receipt line item and include the category in extraction results
- write item categories to Receipt_Line_Items.xlsx for both live and batch processing

## Testing
- `PYTHONPATH='receipt _processor' pytest 'receipt _processor/tests/test_receipt_utils.py'`


------
https://chatgpt.com/codex/tasks/task_e_689276beba548331b220654b02fb9805