### PR TITLE
Refactor item categorization to use YAML mapping

### DIFF
--- a/receipt _processor/receipt_processing/item_categories.yaml
+++ b/receipt _processor/receipt_processing/item_categories.yaml
@@ -1,0 +1,17 @@
+# Keyword mapping for item categories including common OCR errors
+food:
+  - burger
+  - burgcr  # OCR error for "burger"
+  - fries
+  - frics   # OCR error for "fries"
+  - sandwich
+  - sandw1ch  # OCR error for "sandwich"
+drink:
+  - soda
+  - s0da    # OCR error for "soda"
+  - water
+  - waler   # OCR error for "water"
+  - coffee
+  - coffec  # OCR error for "coffee"
+  - cola
+  - co1a    # OCR error for "cola"

--- a/receipt _processor/tests/test_receipt_utils.py
+++ b/receipt _processor/tests/test_receipt_utils.py
@@ -181,7 +181,7 @@ def test_assign_item_category_match():
     assert assign_item_category("Diet Cola", keyword_map) == "beverage"
 
 
-def test_assign_item_category_uncategorized():
+def test_assign_item_category_other():
     keyword_map = {"food": ["burger"]}
-    assert assign_item_category("Laptop Sleeve", keyword_map) == "uncategorized"
+    assert assign_item_category("Laptop Sleeve", keyword_map) == "Other"
 


### PR DESCRIPTION
## Summary
- load line item categories from a configurable YAML file
- default unmatched items to `Other`
- update tests for new categorization behavior

## Testing
- `pip install pandas`
- `pip install pyyaml`
- `PYTHONPATH='receipt _processor' pytest 'receipt _processor/tests'`


------
https://chatgpt.com/codex/tasks/task_e_689283db53cc83318d5414e66bbc0dc6