### PR TITLE
Add PDF manifest combiner utility and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,16 @@ python -m receipt_processing.ml_categorizer <path/to/receipt_log.xlsx>
 This creates `receipt_category_model.joblib`. The main pipeline will use it
 automatically when present.
 
+
+## Combine Manifest PDFs
+
+The `combine_manifest_pdf` module provides a helper and CLI to merge multiple
+manifest PDF files into a single document.
+
+- [User Guide](docs/combine_manifest_pdf_user_guide.md)
+- [Technical Details](docs/combine_manifest_pdf_technical_details.md)
+
+Example usage:
+```bash
+python -m combine_manifest_pdf.main combined.pdf manifest1.pdf manifest2.pdf
+```

--- a/combine_manifest_pdf/__init__.py
+++ b/combine_manifest_pdf/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for combining multiple manifest PDFs into a single document."""
+
+from .main import combine_pdfs
+
+__all__ = ["combine_pdfs"]

--- a/combine_manifest_pdf/main.py
+++ b/combine_manifest_pdf/main.py
@@ -1,0 +1,60 @@
+"""Combine multiple manifest PDFs into one file.
+
+This module exposes a :func:`combine_pdfs` function and can also be
+executed as a script to merge input PDFs into a single output file.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+from PyPDF2 import PdfReader, PdfWriter
+
+
+def combine_pdfs(output_path: str | Path, input_paths: Iterable[str | Path]) -> Path:
+    """Combine multiple PDF files into a single PDF.
+
+    Parameters
+    ----------
+    output_path:
+        Destination file path for the merged PDF.
+    input_paths:
+        Iterable of paths to the PDF files to merge in order.
+
+    Returns
+    -------
+    Path
+        The path to the created PDF file.
+    """
+    writer = PdfWriter()
+    for pdf_path in input_paths:
+        reader = PdfReader(str(pdf_path))
+        for page in reader.pages:
+            writer.add_page(page)
+    output_path = Path(output_path)
+    with output_path.open("wb") as f:
+        writer.write(f)
+    return output_path
+
+
+def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", help="Path to the combined PDF to create")
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help="One or more input PDF files to merge",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _parse_args(argv)
+    combine_pdfs(args.output, args.inputs)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/combine_manifest_pdf_technical_details.md
+++ b/docs/combine_manifest_pdf_technical_details.md
@@ -1,0 +1,20 @@
+# Combine Manifest PDF – Technical Details
+
+The `combine_manifest_pdf` module provides a minimal implementation for
+concatenating PDF files. It relies on the [`PyPDF2`](https://pypi.org/project/PyPDF2/) library
+which handles PDF parsing and writing.
+
+## Module Structure
+- `combine_manifest_pdf/__init__.py` – re-exports the main `combine_pdfs` function.
+- `combine_manifest_pdf/main.py` – implementation and simple command-line
+  interface.
+
+## Implementation Notes
+`combine_pdfs` iterates over each page of the input PDFs using
+`PyPDF2.PdfReader` and appends them to a `PdfWriter` instance. The combined
+pages are written to the output path provided by the caller. No attempt is made
+to optimise or validate the input files beyond what `PyPDF2` performs.
+
+The `main` function exposes a CLI that accepts an output file followed by one or
+more input PDFs. This allows the module to be executed with `python -m
+combine_manifest_pdf.main` without requiring additional wrappers.

--- a/docs/combine_manifest_pdf_user_guide.md
+++ b/docs/combine_manifest_pdf_user_guide.md
@@ -1,0 +1,29 @@
+# Combine Manifest PDF – User Guide
+
+This utility merges multiple shipment manifest PDFs into a single document. It
+can be used either as a library function or run as a small command-line tool.
+
+## Requirements
+- Python 3.9+
+- [PyPDF2](https://pypi.org/project/PyPDF2/)
+
+Install the dependency with:
+```bash
+pip install PyPDF2
+```
+
+## Command-Line Usage
+Merge two or more PDFs into a new file:
+```bash
+python -m combine_manifest_pdf.main combined.pdf manifest1.pdf manifest2.pdf
+```
+The first argument is the output PDF path followed by the input files in the
+desired order.
+
+## Library Usage
+```python
+from combine_manifest_pdf import combine_pdfs
+
+combine_pdfs("combined.pdf", ["manifest1.pdf", "manifest2.pdf"])
+```
+The function returns the path to the created file.

--- a/tests/test_combine_manifest_pdf.py
+++ b/tests/test_combine_manifest_pdf.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from PyPDF2 import PdfReader, PdfWriter
+
+from combine_manifest_pdf import combine_pdfs
+
+
+def _create_dummy_pdf(path: Path) -> None:
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    with path.open("wb") as f:
+        writer.write(f)
+
+
+def test_combine_pdfs(tmp_path: Path) -> None:
+    pdf1 = tmp_path / "a.pdf"
+    pdf2 = tmp_path / "b.pdf"
+    _create_dummy_pdf(pdf1)
+    _create_dummy_pdf(pdf2)
+
+    output = tmp_path / "combined.pdf"
+    result = combine_pdfs(output, [pdf1, pdf2])
+
+    assert result == output
+    assert output.exists()
+
+    reader = PdfReader(str(output))
+    assert len(reader.pages) == 2


### PR DESCRIPTION
## Summary
- add `combine_manifest_pdf` helper with CLI to merge multiple manifest PDFs
- document usage and internals for the new tool
- test PDF merging behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892886b506c8331880d5c972bd27cd8