### PR TITLE
Add receipt confidence scoring and logging

### DIFF
--- a/receipt_processing/__init__.py
+++ b/receipt_processing/__init__.py
@@ -4,6 +4,7 @@ from .utils import (
     ReceiptFields,
     assign_item_category,
     extract_fields,
+    compute_confidence_score,
     load_vendor_categories,
     vendor_csv_to_json,
 )
@@ -12,6 +13,7 @@ __all__ = [
     "ReceiptFields",
     "assign_item_category",
     "extract_fields",
+    "compute_confidence_score",
     "load_vendor_categories",
     "vendor_csv_to_json",
 ]

--- a/tests/test_receipt_utils.py
+++ b/tests/test_receipt_utils.py
@@ -3,6 +3,7 @@ from receipt_processing import (
     extract_fields,
     ReceiptFields,
     assign_item_category,
+    compute_confidence_score,
 )
 
 
@@ -182,4 +183,28 @@ def test_assign_item_category_match():
 def test_assign_item_category_other():
     keyword_map = {"food": ["burger"]}
     assert assign_item_category("Laptop Sleeve", keyword_map) == "Other"
+
+
+def test_confidence_score_high():
+    lines = [
+        "Store",
+        "Date: 01/01/2024",
+        "Apple 1.00",
+        "Banana 1.00",
+        "Subtotal 2.00",
+        "Tax 0.16",
+        "Total 2.16",
+        "Visa **** 1234",
+        "2 items",
+    ]
+    fields = extract_fields(lines)
+    score = compute_confidence_score(fields)
+    assert score == 1.0
+
+
+def test_confidence_score_low():
+    lines = ["Store", "Total 10.00"]
+    fields = extract_fields(lines)
+    score = compute_confidence_score(fields)
+    assert score < 0.5
 


### PR DESCRIPTION
## Summary
- compute heuristic confidence score for parsed receipts and expose via package API
- log receipts with low confidence and record scores in Excel log
- test confidence scoring and update utils/tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689383c478a08331b4a80ab03e5c0090